### PR TITLE
Homepage and Item pages can now include context

### DIFF
--- a/_items/t86-243.md
+++ b/_items/t86-243.md
@@ -3,3 +3,4 @@ layout: item
 title: T86-243
 manifest_name: t86-243
 ---
+<!-- Add commentary or other material below this line.  Markdown or HTML is allowed. -->

--- a/_items/t86-244.md
+++ b/_items/t86-244.md
@@ -3,3 +3,4 @@ layout: item
 title: T86-244
 manifest_name: t86-244
 ---
+<!-- Add commentary or other material below this line.  Markdown or HTML is allowed. -->

--- a/_items/t86-245.md
+++ b/_items/t86-245.md
@@ -3,3 +3,4 @@ layout: item
 title: T86-245
 manifest_name: t86-245
 ---
+<!-- Add commentary or other material below this line.  Markdown or HTML is allowed. -->

--- a/_layouts/item.html
+++ b/_layouts/item.html
@@ -2,7 +2,7 @@
 layout: page
 ---
 
-
+{{ content }}
 
  <div id="uv" class="uv"></div>
 

--- a/index.markdown
+++ b/index.markdown
@@ -4,3 +4,5 @@
 
 layout: home
 ---
+
+<!-- Add commentary or other material below this line.  Markdown or HTML is allowed. -->


### PR DESCRIPTION
This change allows the repository owner to edit the homepage or item markdown files and add content to them that will be displayed on the generated edition site on either the homepage or above UV on the item page.